### PR TITLE
wip1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,3 +7,4 @@ add_library( subtri SHARED
   )
 include_directories( ../../lwtv/src ../src)
 add_executable(tester tester.C)
+install(TARGETS subtri)  # adds 'make install' target

--- a/src/subtri.C
+++ b/src/subtri.C
@@ -28,7 +28,7 @@ printout(int iter, vector<subtri<T>> &subtriList)
 */
 template <typename T>
 void
-subdividedMesh<T>::subdivide(int maxIter, T maxRatio, void *args)
+subdividedMesh<T>::subdivide(int maxIter, T maxRatio, void *args) // pass args const ref instead of void ?
 {
   cout<<"maxratio: "<<maxRatio<<endl;
   for(int i = 0; i<maxIter; ++i){
@@ -96,10 +96,10 @@ void
 subdividedMesh<T>::splitSort(void *args, int iter)
 {
   //typename vector<subtri<T>*>::iterator tri;
-  typename vector<unsigned int>::iterator triIdx;
+  //typename vector<unsigned int>::iterator triIdx;  // not needed - use auto instead
   //bool dump = false;
   //for (tri = newTriGroup.begin(); tri != newTriGroup.end(); ++tri){
-  for (triIdx = newTriList.begin(); triIdx != newTriList.end(); ++triIdx){
+  for (auto triIdx = newTriList.begin(); triIdx != newTriList.end(); ++triIdx){
     if((subtriList[*triIdx].cen.circumRadius / subtriList[*triIdx].cen.inRadius) > 10){
       for(int i=0; i<3;++i){
         if(subtriList[subtriList[*triIdx].neighbors[i].get()].splitState == NOT_SPLIT){
@@ -111,12 +111,12 @@ subdividedMesh<T>::splitSort(void *args, int iter)
   }
 
 
-  for (triIdx = newTriList.begin(); triIdx != newTriList.end(); ++triIdx){
+  for (auto triIdx = newTriList.begin(); triIdx != newTriList.end(); ++triIdx){
     //if(*triIdx == 166)cout<<"~~~~~~~~~~~~~   I GOT 166!!!!!!!!!!!!!!"<<endl;
     if(subtriList[*triIdx].splitState != FINISHED){
       //if(*triIdx == 166)cout<<" testing 166 "<<endl;
       if(subtriList[*triIdx].splitState != NEW_TRI)cout<<" got a not new, "<<(*triIdx)<<", state: "<<subtriList[*triIdx].splitState<<endl;
-      bool split = testSplit(&(subtriList[*triIdx]), args);
+      bool split = testSplit(&(subtriList[*triIdx]), args); // testSplit only implemented in derrived?
 
       if(split){
         //if(*triIdx == 166)cout<<" 166 is split"<<endl;

--- a/src/subtri.h
+++ b/src/subtri.h
@@ -120,8 +120,8 @@ class subdividedMesh
   void flipTest(T maxRatio);
   void createGeo();
   void sew(T maxRatio);
-  virtual bool testSplit(subtri<T> *tri, void *args) = 0;
-  virtual void movePoints(void *args) = 0;
+  virtual bool testSplit(subtri<T> *tri, void *args) = 0;  // why virtual?
+  virtual void movePoints(void *args) = 0;  // why virtual?
   vector<subtri<T>*> newTriGroup;
   vector<unsigned int> newTriList;
   //---------------------------------------------------------------------

--- a/src/tester.C
+++ b/src/tester.C
@@ -20,14 +20,14 @@ class testMesh : public subdividedMesh<T>
 using subdividedMesh<T>::pointList;
 using subdividedMesh<T>::subtriList;
 using subdividedMesh<T>::newPointsGroup;
-bool testSplit(subtri<T> *tri, void *args)
+bool testSplit(subtri<T> *tri, void *args)  // perhaps pass everything by const &  ?
 {
 	subtri<T> spit(*tri);
 	argsStruct<T> *myArgs = (argsStruct<T>*)args;
-  tvec3<T> cenLoc = tri->centroidLoc(pointList);
+	tvec3<T> cenLoc = tri->centroidLoc(pointList);  // cenLoc could be const but operator > does not handle it
  	float mult = 1;
 	if(cenLoc[0]>0)mult = myArgs->resmult;
-	T triRadius = tri->maxRad(pointList);
+	const T triRadius = tri->maxRad(pointList);
 	if(triRadius > (myArgs->triradius*mult)){
   	return true;
 	}


### PR DESCRIPTION
Just a few observations while looking thru the code. (This draft PR is not intended to be merged)
Key things:
- add install target to cmake - for all projects so you can configure and install in the right place. For instance:
`cmake ../src -DCMAKE_INSTALL_PREFIX=$HOME/houdini18.0/`
- avoid verbose iterator typedefs and use `auto ` instead 
- perhaps replace some pointer function arguments (and C casts insidef functions) with pass by const &
- The pure virtuals testSplit() and movePoints() where one has implementation in the base class, the other does not. What is the intention behind?